### PR TITLE
replace webextension-polyfill-ts with webextension-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "build": "tsc"
   },
   "dependencies": {
-    "webextension-polyfill-ts": "^0.19.0"
+    "webextension-polyfill": "^0.9.0"
   },
   "devDependencies": {
+    "@types/webextension-polyfill": "^0.8.3",
     "comlink": "^4.3.0",
     "typescript": "^3.9.6"
   }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,4 +1,4 @@
-import { browser, Runtime } from "webextension-polyfill-ts";
+import browser, { Runtime } from "webextension-polyfill";
 import * as Comlink from "comlink";
 
 const SYMBOL = "__PORT__@";

--- a/src/backgroundEndpoint.ts
+++ b/src/backgroundEndpoint.ts
@@ -1,4 +1,4 @@
-import { Runtime, browser } from "webextension-polyfill-ts";
+import browser, { Runtime } from "webextension-polyfill";
 import { forward, isMessagePort, createEndpoint } from "./adapter";
 
 const portCallbacks = new Map<string, ((port: Runtime.Port) => void)[]>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/webextension-polyfill@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.8.3.tgz#eb601b3fcf524f0ecf7d7579ccbd237928d0dda7"
+  integrity sha512-GN+Hjzy9mXjWoXKmaicTegv3FJ0WFZ3aYz77Wk8TMp1IY3vEzvzj1vnsa0ggV7vMI1i+PUxe4qqnIJKCzf9aTg==
+
 comlink@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.0.tgz#80b3366baccd87897dab3638ebfcfae28b2f87c7"
@@ -12,14 +17,7 @@ typescript@^3.9.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
   integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
-webextension-polyfill-ts@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill-ts/-/webextension-polyfill-ts-0.19.0.tgz#3e3a059c656936c853b47d2a57bf114c615c1e1e"
-  integrity sha512-VcA7bdf0dzUc8JXQwQU+spSUTV0Gc0Y7VPsdrEFLbuTxJluC4xBoKVWtfUXRqykVfDvFsfo591+p1MmPSJezsw==
-  dependencies:
-    webextension-polyfill "^0.6.0"
-
-webextension-polyfill@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.6.0.tgz#1afd925f3274a0d4848083579b9c0b649a5c6763"
-  integrity sha512-PlYwiX8e4bNZrEeBFxbFFsLtm0SMPxJliLTGdNCA0Bq2XkWrAn2ejUd+89vZm+8BnfFB1BclJyCz3iKsm2atNg==
+webextension-polyfill@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz#de6c1941d0ef1b0858b20e9c7b46bbc042c5a960"
+  integrity sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw==


### PR DESCRIPTION
Using comlink-extension out of the box gives an error that `browser.runtime` is not defined. This replacement is recommended by [webextension-polyfill-ts](https://github.com/Lusito/webextension-polyfill-ts#news-this-has-changed-to-be-a-pure-generator-project).