### PR TITLE
Update typescript and remove setting and variables

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -27,7 +27,7 @@ export function createEndpoint(
 
   function serialize(data: any): void {
     if (Array.isArray(data)) {
-      data.forEach((value, i) => {
+      data.forEach((value) => {
         serialize(value);
       });
     } else if (data && typeof data === "object") {
@@ -97,7 +97,7 @@ export function createEndpoint(
   }
 
   return {
-    postMessage: (message, transfer: MessagePort[]) => {
+    postMessage: (message) => {
       serialize(message);
       port.postMessage(message);
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": false,
-    "noImplicitUseStrict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "CommonJS",
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@ comlink@^4.4.1:
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.1.tgz#e568b8e86410b809e8600eb2cf40c189371ef981"
   integrity sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q==
 
-typescript@5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+typescript@^5.1.6:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 webextension-polyfill@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
To be able to build `comlink-extension`, I do the following:
* Update typescript to 5.7.2
* Remove`noImplicitUseStrict` in `tsconfig.json`: it deprecated and disabled in typescript 5.5 ( https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#disabling-features-deprecated-in-typescript-5.0 )
* Remove unused variables